### PR TITLE
fix: add creamsody to custom theme load path

### DIFF
--- a/creamsody-theme.el
+++ b/creamsody-theme.el
@@ -1278,6 +1278,7 @@
 
 (defalias 'creamsody-modeline 'creamsody-modeline-one)
 
+;;;###autoload
 (and load-file-name
      (boundp 'custom-theme-load-path)
      (add-to-list 'custom-theme-load-path


### PR DESCRIPTION
I _think_ this fixes #6. I tried my local changes using `package-install-file` and it did make `creamsody` appear in `theme-load`, but I've barely read/written Emacs Lisp so I might be completely mislead.